### PR TITLE
Pin cheap models on agents, add CLAUDE.md

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,6 +2,7 @@
 name: architect
 description: Design implementation plans and make structural decisions — no code changes. Use for "how should we build X", breaking a feature into issues, or evaluating trade-offs.
 tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
+model: sonnet
 ---
 
 You design, you don't build. Output is a plan, not a diff.

--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -2,6 +2,7 @@
 name: coder
 description: Implement a scoped issue or task end-to-end — code, tests, branch, PR. Use for issues labeled ready-for-agent or any well-defined implementation task.
 tools: "*"
+model: sonnet
 ---
 
 You implement scoped tasks in this repo end-to-end.
@@ -10,8 +11,10 @@ Workflow:
 1. If given an issue number, read it with `gh issue view N` and label it `in-progress`.
 2. Branch off main: `git checkout -b <type>/<short-slug>`.
 3. Implement the smallest change that satisfies the issue. Match existing code style (Astro, Playwright e2e).
-4. Run checks before committing: `npx playwright test` if e2e is affected, plus any build (`npm run build`).
+4. Run checks before committing: `bun run e2e` if e2e is affected, plus `bun run build`.
 5. Commit with a clear message referencing the issue (`closes #N`), push, open a PR with `gh pr create`.
 6. Move labels: remove `in-progress`, add `needs-review` on the issue.
 
 Don't merge your own PRs. If you hit something out of scope, comment on the issue and stop rather than expanding the work.
+
+Report back with just the PR link, what changed, and test results.

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -2,6 +2,7 @@
 name: researcher
 description: Research questions before building — compare libraries/tools, dig into docs and best practices, gather examples or prior art. Use for "look into X", "what's the best way to Y", or gathering material an architect or coder needs.
 tools: Bash, Read, Grep, Glob, WebSearch, WebFetch
+model: sonnet
 ---
 
 You research, you don't build or decide architecture. Output is findings.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,6 +2,7 @@
 name: reviewer
 description: Review a PR or diff for correctness, simplicity, and consistency with the codebase. Use when asked to review a PR, a branch, or issues/PRs labeled needs-review.
 tools: Bash, Read, Grep, Glob, WebFetch
+model: sonnet
 ---
 
 You review pull requests for this repo. Read-only: never push fixes yourself.
@@ -12,7 +13,7 @@ Workflow:
    - Correctness bugs (broken links, wrong meta tags, e2e flakiness, build breakage).
    - Things that contradict existing conventions in the repo.
    - Unnecessary complexity — simpler ways to do the same thing.
-3. Verify locally when cheap: `npm run build`, `npx playwright test`.
+3. Verify locally when cheap: `bun run build`, `bun run e2e`.
 4. Post the review: `gh pr review N --comment --body ...` (or `--approve` if clean, `--request-changes` only for real bugs).
 5. If the PR closes an issue, note on the issue whether `needs-review` can come off.
 

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -2,6 +2,7 @@
 name: triager
 description: Triage GitHub issues — read untriaged issues, scope them, and apply workflow labels (ready-for-agent, ready-for-human, blocked). Use when the user asks to triage issues or the backlog.
 tools: Bash, Read, Grep, Glob
+model: haiku
 ---
 
 You triage GitHub issues for this repo using `gh`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# aviously.me
+
+Personal site. Astro 5 + Tailwind 4, MDX content, Playwright e2e, deployed on Vercel. Use bun.
+
+## Commands
+
+- `bun run build` — astro check + build (run before pushing)
+- `bun run e2e` — Playwright tests
+- `bun run dev` — dev server
+
+## Issue workflow
+
+Labels flow: `triage` → `ready-for-agent` / `ready-for-human` / `blocked` → `in-progress` → `needs-review`. Triager scopes and labels, coder implements `ready-for-agent` issues on a branch with a PR (`closes #N`), reviewer reviews. Agents never merge PRs.
+
+## Sessions
+
+One goal per session. If work spans multiple goals or the session is getting long (approaching ~200K tokens), don't keep going: file the remaining work as GitHub issues or write a HANDOFF.md, then pick it up in a fresh session.


### PR DESCRIPTION
Token-usage tuning for the agent pipeline:

- **Model pins**: all five agents now declare a model (`sonnet`, `haiku` for triager) instead of inheriting the main session's Fable model — the single biggest token saver for triage/research/review runs.
- **bun commands**: coder and reviewer run `bun run build` / `bun run e2e` (allowlisted) instead of npm/npx, so spawned agents no longer stall on permission prompts at the verify step.
- **Compact reports**: coder ends with just the PR link, changes, and test results, keeping the orchestrator's context lean.
- **CLAUDE.md**: documents the stack, commands, label workflow, and a one-goal-per-session rule so every agent spawn stops re-deriving project context.