### PR TITLE
Add /services page + case-study links for client-facing positioning

### DIFF
--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test'
 
-const pages = ['/', '/about/', '/work/', '/experience/', '/open-source/', '/contact/', '/resume/', '/now/']
+const pages = ['/', '/about/', '/work/', '/experience/', '/open-source/', '/contact/', '/resume/', '/now/', '/services/']
 
 for (const path of pages) {
   test(`${path} renders`, async ({page}) => {
@@ -10,6 +10,14 @@ for (const path of pages) {
     await expect(page).toHaveTitle(/Avi Charlop/)
   })
 }
+
+test('services page is linked from home and links both case studies', async ({page}) => {
+  await page.goto('/')
+  await expect(page.locator('a[href="/services/"]').first()).toBeVisible()
+  await page.goto('/services/')
+  await expect(page.locator('a[href="/work/closer/"]').first()).toBeVisible()
+  await expect(page.locator('a[href="/work/vionlabs-customer-portal/"]').first()).toBeVisible()
+})
 
 test('blog is not linked in navigation', async ({page}) => {
   await page.goto('/')

--- a/src/content/projects/vionlabs-customer-portal.mdx
+++ b/src/content/projects/vionlabs-customer-portal.mdx
@@ -14,11 +14,18 @@ featured: true
 order: 1
 ---
 
-The important shape of the work was greenfield product delivery with enough platform discipline to keep rapid customer iteration from turning into operational drag.
+The important shape of the work was greenfield product delivery with enough platform discipline to keep rapid customer iteration from turning into operational drag. The approach was a single Turborepo monorepo holding every surface — portal, public API, sync services, docs, design system — so the 4-engineer team shared one set of types, conventions, and deploy paths.
 
-## Highlights
+## What shipped
 
-- Led a 4-engineer remote team.
-- Unified multiple upstream systems behind a customer portal.
-- Established monorepo standards for frontend, backend, and documentation surfaces.
-- Built deployment paths around Terraform-managed GCP infrastructure and GitLab CI/CD.
+- A Turborepo monorepo: Next.js 15 / React 19 portal, tRPC app API, a public Fastify API for customer integrations, Drizzle ORM on Cloud SQL Postgres, and a Fumadocs developer-docs site.
+- Two Fastify data-sync services pulling catalog data from Vionlabs' upstream content-fingerprinting systems into the portal database — the "multi-source" part of the platform.
+- Catalog browsing and management for large video catalogs: list and table views, filtering and sorting, tagging, smart lists, and multi-tenant orgs with per-catalog entitlements.
+- Enterprise auth: WorkOS SSO, scoped API keys, and machine-to-machine auth.
+- A Figma-driven Tailwind design system with Storybook stories.
+- GCP infrastructure entirely in Terraform — Cloud Run, Cloud SQL, Pub/Sub, Eventarc, Secret Manager, VPC, Artifact Registry — deployed through GitLab CI/CD.
+
+## Outcome
+
+- Second-most-active contributor (~480 commits) while leading the 4-engineer remote team.
+- Enterprise customers onboarded onto the portal, with Sales feedback shipping same-day against a stable platform foundation.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,6 +16,7 @@ const featuredProjects = projects.filter((project) => project.data.featured).sli
     <div>
       <p class="eyebrow">`currently`</p>
       <AvailabilityBadge />
+      <p class="availability-note"><a href="/services/">Available for one client engagement →</a></p>
       <h1>Senior full-stack engineer building fast, thoughtful product systems.</h1>
       <p class="lead">
         I’m Avi Charlop, a senior full-stack engineer and team lead with 10+ years of experience across React,

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -11,6 +11,7 @@ ${site.tagline}
 ## Pages
 
 - [About](${site.url}/about/): professional story, working style, and strengths
+- [Services](${site.url}/services/): client engagements - zero-to-shipped TypeScript platforms and infra automation
 - [Work](${site.url}/work/): case studies of selected projects
 - [Experience](${site.url}/experience/): full role history
 - [Resume](${site.url}/resume/): resume with PDF download

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -90,7 +90,7 @@ const services = [
       href="/experience/"
       linkLabel="Full experience"
     />
-    <div class="grid-3">
+    <div class="grid-2">
       {caseStudies.map((project) => <ProjectCard project={project} />)}
     </div>
   </section>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,0 +1,112 @@
+---
+import {getCollection} from 'astro:content'
+import Layout from '@/components/Layout.astro'
+import ProjectCard from '@/components/ProjectCard.astro'
+import SectionHeading from '@/components/SectionHeading.astro'
+import {site} from '@/data/site'
+
+const projects = await getCollection('projects')
+const caseStudySlugs = ['closer', 'vionlabs-customer-portal']
+const caseStudies = caseStudySlugs
+  .map((slug) => projects.find((project) => project.id.replace(/\.mdx?$/, '') === slug))
+  .filter((project) => project !== undefined)
+
+const services = [
+  {
+    kicker: 'product',
+    title: 'Greenfield product',
+    text: 'The application itself: Next.js or Astro frontends, typed APIs (tRPC, Fastify, Elysia), Postgres with Drizzle, auth, payments, and the integrations your product depends on.',
+  },
+  {
+    kicker: 'infrastructure',
+    title: 'Infra and automation',
+    text: 'The platform it runs on: cloud provisioning as code (Terraform on GCP, provider APIs elsewhere), CI/CD pipelines, environments, secrets, and deploys that work on day one.',
+  },
+  {
+    kicker: 'foundations',
+    title: 'Monorepo and tooling',
+    text: 'The structure your next hires inherit: Turborepo or Bun workspaces, shared config, typed environment variables, e2e tests, docs, and conventions written down.',
+  },
+]
+---
+
+<Layout
+  title="Services - Avi Charlop"
+  description="Zero-to-shipped TypeScript platforms and infra automation. One senior engineer takes your product from empty repo to running in production — application, infrastructure, and CI/CD included."
+  canonical="/services/"
+>
+  <section class="shell page-hero">
+    <p class="eyebrow">`services`</p>
+    <h1>Zero-to-shipped TypeScript platforms and infra automation.</h1>
+    <p class="lead">
+      I’m Avi Charlop, a senior full-stack engineer with 10+ years of experience. I take products from empty repo to
+      running in production — the application and the infrastructure it runs on — as one engineer, so you don’t have to
+      hire a team before you have a product.
+    </p>
+    <div class="button-row">
+      <a class="button" href={`mailto:${site.email}`}>Email me</a>
+      <a class="button secondary" href="/contact/">Contact page</a>
+    </div>
+  </section>
+
+  <section class="shell section">
+    <SectionHeading
+      kicker="what_i_deliver"
+      title="The product, plus the platform it runs on."
+      text="Most early builds ship the app and defer the infrastructure. I deliver both, so the first version is also deployable, testable, and maintainable."
+    />
+    <div class="grid-3">
+      {services.map((service) => (
+        <article class="card">
+          <p class="meta-label">{service.kicker}</p>
+          <h3>{service.title}</h3>
+          <p>{service.text}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="shell section">
+    <div class="signal-card">
+      <p class="meta-label">`who_this_is_for`</p>
+      <h2>Small teams and founders without a platform team.</h2>
+      <p>
+        You have a product to build and nobody whose job is repos, pipelines, and cloud accounts. I set those up as part
+        of building the product, then hand over code and infrastructure definitions your future hires can work in — not
+        a dependency on me.
+      </p>
+      <p>
+        I work in the open: pull requests, architecture decision records, and docs where the project warrants them. I
+        take one client engagement at a time.
+      </p>
+    </div>
+  </section>
+
+  <section class="shell section">
+    <SectionHeading
+      kicker="proof"
+      title="Two recent builds, end to end."
+      text="Both were greenfield: one engineer or a small team, a typed TypeScript codebase, and the provisioning, CI/CD, and cloud infrastructure delivered alongside the product."
+      href="/experience/"
+      linkLabel="Full experience"
+    />
+    <div class="grid-3">
+      {caseStudies.map((project) => <ProjectCard project={project} />)}
+    </div>
+  </section>
+
+  <section class="shell section">
+    <div class="signal-card">
+      <p class="meta-label">`next_step`</p>
+      <h2>Have something that needs to go from zero to shipped?</h2>
+      <p class="lead">
+        Send a short note about what you’re building and where it’s stuck. I’ll reply with whether I can help and what a
+        first step could look like.
+      </p>
+      <div class="button-row">
+        <a class="button" href={`mailto:${site.email}`}>{site.email}</a>
+        <a class="button secondary" href="/contact/">Use the contact form</a>
+      </div>
+    </div>
+  </section>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -416,6 +416,15 @@ h3 {
   }
 }
 
+.availability-note {
+  margin-top: 10px;
+  font-size: 0.92rem;
+}
+
+.availability-note a {
+  color: var(--accent);
+}
+
 .code-note {
   margin-top: 24px;
   padding: 16px;


### PR DESCRIPTION
Closes #29

## What this does

- **New `/services` page** — the outreach URL. Pitch: zero-to-shipped TypeScript platforms & infra automation, delivered by one senior engineer. Stands alone for zero-context readers; sections: what I deliver (product / infra / monorepo-tooling), who it's for, proof (two case studies), contact CTA (mailto + existing /contact — no new form backend, that's #16). OG meta comes from the shared Layout title/description. No pricing anywhere.
- **Case studies** — reuses the existing published entries at `/work/closer/` and `/work/vionlabs-customer-portal/` (the `work/[slug].astro` template already has the stack/links sidebar from #18). Closer was already detailed; the Vionlabs body was thin, so it's enriched from `docs/jobs/vionlabs.writeup.md` with approach / what shipped / outcome. Frontmatter (used on /work and homepage cards) untouched.
- **Homepage** — one availability line in the hero linking to `/services/` ("Available for one client engagement"), plus a small `.availability-note` CSS rule.
- **llms.txt** — lists the new page.
- **e2e** — `/services/` added to the page smoke tests, plus a test asserting homepage → /services and /services → both case studies.

## What to review

- Voice/copy on `src/pages/services.astro` and the new Vionlabs body — written plain and first-person, but you'll want to pass over it.
- Whether /services should also go in the nav (kept out to stay minimal; it's linked from the homepage hero).
- The availability line wording/placement in the hero.

## Checks

- `npm run build` (astro check + build) passes.
- Playwright: 96 passed; the 2 failures (`contact form posts to a real backend`, chromium + mobile-safari) also fail on a clean tree locally — missing `CF_TURNSTILE_SITE_KEY` env, pre-existing and unrelated.
- /resume and /experience untouched.

https://claude.ai/code/session_01SmrVnTL2JhjZjPnKTyqESs