### PR TITLE
Fix e2e CI against Vercel deployments

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,8 @@ jobs:
         env:
           # Production deploys get the clean domain; previews get their unique URL.
           BASE_URL: ${{ github.event.inputs.url || (github.event.deployment_status.environment == 'Production' && 'https://aviously.me') || github.event.deployment_status.environment_url }}
+          # Gets CI past Vercel Deployment Protection on preview URLs.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,9 +1,15 @@
 import {expect, test} from '@playwright/test'
 
 test('header navigation reaches every page', async ({page, isMobile}) => {
-  const links = ['About', 'Work', 'Experience', 'Open Source', 'Contact']
+  const links = [
+    {label: 'About', path: '/about/'},
+    {label: 'Work', path: '/work/'},
+    {label: 'Experience', path: '/experience/'},
+    {label: 'Open Source', path: '/open-source/'},
+    {label: 'Contact', path: '/contact/'},
+  ]
 
-  for (const label of links) {
+  for (const {label, path} of links) {
     await page.goto('/')
     if (isMobile) {
       // The menu listener is a deferred module script; retry until it has attached.
@@ -15,6 +21,11 @@ test('header navigation reaches every page', async ({page, isMobile}) => {
     } else {
       await page.locator('header nav.desktop-nav').getByRole('link', {name: label}).click()
     }
+    // Wait for the navigation to actually commit before asserting content —
+    // the h1 check alone can pass against the previous page (every page has
+    // one), leaving the click's navigation in flight when the next goto('/')
+    // starts, which webkit reports as "interrupted by another navigation".
+    await expect(page).toHaveURL(path)
     await expect(page.locator('h1').first()).toBeVisible()
   }
 })

--- a/e2e/qa.spec.ts
+++ b/e2e/qa.spec.ts
@@ -67,6 +67,9 @@ for (const path of pages) {
 
   test(`${path} has no horizontal overflow`, async ({page}) => {
     await page.goto(path)
+    // Measure the settled layout: font-display swap means fallback metrics
+    // (wider on Linux) are live for a moment after load.
+    await page.evaluate(() => document.fonts.ready)
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
     )

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,8 +14,18 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     // Stop Vercel injecting its toolbar overlay on preview deployment URLs;
-    // it intercepts pointer events and breaks click-based tests.
-    extraHTTPHeaders: {'x-vercel-skip-toolbar': '1'},
+    // it intercepts pointer events and breaks click-based tests. The bypass
+    // header gets CI past Deployment Protection (Vercel SSO) on preview URLs —
+    // without it every request is answered with Vercel's login page.
+    extraHTTPHeaders: {
+      'x-vercel-skip-toolbar': '1',
+      ...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+        ? {
+            'x-vercel-protection-bypass':
+              process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+          }
+        : {}),
+    },
   },
   projects: [
     {name: 'chromium', use: {...devices['Desktop Chrome']}},

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -283,6 +283,9 @@ h3 {
   font-family: var(--font-display);
   font-weight: 600;
   line-height: 1.02;
+  /* Fallback fonts (Linux: DejaVu Sans) are wider than Cal Sans; before the
+     webfont swaps in, a long heading word can spill past the viewport. */
+  overflow-wrap: break-word;
 }
 
 h1 {


### PR DESCRIPTION
## Problem
Every PR has shown a red e2e check since the learning-app merge. Three separate causes:

1. **Preview runs tested Vercel's login page.** Deployment Protection (Vercel SSO) is enabled for preview URLs, so CI never reached the site — nearly the whole suite failed.
2. **`/app` island crashes on preview builds.** `PUBLIC_CONVEX_URL` was configured for the Production target only; `src/lib/convex.ts` throws when it's missing, so the sign-in gate never renders.
3. **`header navigation reaches every page` flakes on mobile-safari** (this one also hit production runs): the `h1` assertion can pass against the *previous* page before the clicked navigation commits, so the next `goto('/')` races it — "interrupted by another navigation".

## Fix
- Playwright sends `x-vercel-protection-bypass` when `VERCEL_AUTOMATION_BYPASS_SECRET` is set (added to Actions secrets, using the project's existing automation-bypass secret). Verified manually: preview `/app` returns the real page with the header.
- Workflow passes the secret to the test step.
- Nav test asserts `toHaveURL` after each click before checking content.
- (Outside this diff) `PUBLIC_CONVEX_URL` needs adding to the Preview env target on Vercel — previews built before that will still fail the sign-in gate test.

All 100 tests pass locally.