### PR TITLE
feat(tokens): paper/ink palette, Space Grotesk + Space Mono, ink dark theme (#38)

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -70,8 +70,8 @@ const jsonLd = [
     <script is:inline>
       const applyTheme = () => {
         const storedTheme = localStorage.getItem('theme')
-        const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches
-        document.documentElement.dataset.theme = storedTheme || (prefersLight ? 'light' : 'dark')
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+        document.documentElement.dataset.theme = storedTheme || (prefersDark ? 'dark' : 'light')
       }
       applyTheme()
       document.addEventListener('astro:after-swap', applyTheme)

--- a/src/components/app/LessonViewer.tsx
+++ b/src/components/app/LessonViewer.tsx
@@ -20,7 +20,7 @@ export function LessonViewer({lesson, onBack}: {lesson: Doc<'lessons'>; onBack: 
           <button
             type='button'
             onClick={() => void setStatus({lessonId: lesson._id, status: 'in_progress'})}
-            className={`rounded-md border px-2 py-1 text-xs ${
+            className={`border px-2 py-1 text-xs ${
               lesson.status === 'in_progress'
                 ? 'border-[var(--amber)] text-[var(--amber)]'
                 : 'border-[var(--line)] text-[var(--faint)] hover:text-[var(--text)]'
@@ -31,7 +31,7 @@ export function LessonViewer({lesson, onBack}: {lesson: Doc<'lessons'>; onBack: 
           <button
             type='button'
             onClick={() => void setStatus({lessonId: lesson._id, status: 'done'})}
-            className={`rounded-md border px-2 py-1 text-xs ${
+            className={`border px-2 py-1 text-xs ${
               lesson.status === 'done'
                 ? 'border-[var(--green)] text-[var(--green)]'
                 : 'border-[var(--line)] text-[var(--faint)] hover:text-[var(--text)]'

--- a/src/components/app/SignIn.tsx
+++ b/src/components/app/SignIn.tsx
@@ -43,7 +43,7 @@ export function SignIn() {
           required
           autoComplete='email'
           placeholder='Email'
-          className='rounded-md border border-[var(--line)] bg-[var(--surface)] px-3 py-2 text-[var(--text)] outline-none focus:border-[var(--accent)]'
+          className='border border-[var(--line)] bg-[var(--surface)] px-3 py-2 text-[var(--text)] outline-none focus:border-[var(--accent)]'
         />
         <input
           name='password'
@@ -51,13 +51,13 @@ export function SignIn() {
           required
           autoComplete={flow === 'signIn' ? 'current-password' : 'new-password'}
           placeholder='Password'
-          className='rounded-md border border-[var(--line)] bg-[var(--surface)] px-3 py-2 text-[var(--text)] outline-none focus:border-[var(--accent)]'
+          className='border border-[var(--line)] bg-[var(--surface)] px-3 py-2 text-[var(--text)] outline-none focus:border-[var(--accent)]'
         />
         {error && <p className='text-sm text-[var(--danger)]'>{error}</p>}
         <button
           type='submit'
           disabled={submitting}
-          className='rounded-md bg-[var(--accent)] px-3 py-2 font-medium text-[var(--bg)] disabled:opacity-60'
+          className='bg-[var(--accent)] px-3 py-2 font-medium text-[var(--on-accent)] disabled:opacity-60'
         >
           {submitting ? '…' : flow === 'signIn' ? 'Sign in' : 'Create account'}
         </button>

--- a/src/components/app/WorkspaceList.tsx
+++ b/src/components/app/WorkspaceList.tsx
@@ -30,7 +30,7 @@ export function WorkspaceList() {
               <li key={ws._id}>
                 <a
                   href={`/app?w=${encodeURIComponent(ws.slug)}`}
-                  className='block rounded-lg border border-[var(--line)] bg-[var(--surface)] p-4 transition-colors hover:border-[var(--accent)]'
+                  className='block border border-[var(--line)] bg-[var(--surface)] p-4 transition-colors hover:border-[var(--accent)]'
                 >
                   <div className='flex items-baseline justify-between gap-3'>
                     <span className='font-medium'>{ws.title}</span>
@@ -39,8 +39,8 @@ export function WorkspaceList() {
                     </span>
                   </div>
                   {ws.mission && <p className='mt-1 line-clamp-2 text-sm text-[var(--muted)]'>{ws.mission}</p>}
-                  <div className='mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--bg-2)]'>
-                    <div className='h-full rounded-full bg-[var(--green)]' style={{width: `${pct}%`}} />
+                  <div className='mt-3 h-1.5 overflow-hidden bg-[var(--bg-2)]'>
+                    <div className='h-full bg-[var(--green)]' style={{width: `${pct}%`}} />
                   </div>
                 </a>
               </li>

--- a/src/components/app/WorkspaceView.tsx
+++ b/src/components/app/WorkspaceView.tsx
@@ -50,13 +50,9 @@ export function WorkspaceView({slug}: {slug: string}) {
                 <button
                   type='button'
                   onClick={() => setOpenLesson(lesson)}
-                  className='flex w-full items-center gap-3 rounded-md px-3 py-2 text-left hover:bg-[var(--surface)]'
+                  className='flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-[var(--surface)]'
                 >
-                  <span
-                    aria-hidden
-                    className='h-2 w-2 shrink-0 rounded-full'
-                    style={{background: statusDot[lesson.status]}}
-                  />
+                  <span aria-hidden className='h-2 w-2 shrink-0' style={{background: statusDot[lesson.status]}} />
                   <span className='flex-1 truncate'>{lesson.title}</span>
                   {lesson.status === 'done' && <span className='text-xs text-[var(--green)]'>done</span>}
                 </button>
@@ -74,7 +70,7 @@ export function WorkspaceView({slug}: {slug: string}) {
                 <button
                   type='button'
                   onClick={() => openInNewTab(doc.html)}
-                  className='w-full truncate rounded-md px-3 py-2 text-left text-[var(--accent)] hover:bg-[var(--surface)]'
+                  className='w-full truncate px-3 py-2 text-left text-[var(--accent)] hover:bg-[var(--surface)]'
                 >
                   {doc.title} ↗
                 </button>
@@ -89,7 +85,7 @@ export function WorkspaceView({slug}: {slug: string}) {
           <ul className='flex flex-col gap-2'>
             {learningRecords.map((rec) => (
               <li key={rec._id}>
-                <details className='rounded-md border border-[var(--line)] bg-[var(--surface)]'>
+                <details className='border border-[var(--line)] bg-[var(--surface)]'>
                   <summary className='cursor-pointer px-3 py-2 font-medium'>{rec.title}</summary>
                   <Markdown source={rec.markdown} className='px-3 pb-3 text-sm text-[var(--muted)]' />
                 </details>

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -94,12 +94,12 @@ const {title = 'Learning'} = Astro.props
     font-size: 0.85em;
     background: var(--bg-2);
     padding: 0.1em 0.35em;
-    border-radius: 4px;
+    border-radius: var(--radius);
   }
   .md-body pre {
     background: var(--bg-2);
     padding: 0.8em 1em;
-    border-radius: 6px;
+    border-radius: var(--radius);
     overflow-x: auto;
   }
   .md-body pre code {

--- a/src/layouts/AppLayout.astro
+++ b/src/layouts/AppLayout.astro
@@ -94,12 +94,10 @@ const {title = 'Learning'} = Astro.props
     font-size: 0.85em;
     background: var(--bg-2);
     padding: 0.1em 0.35em;
-    border-radius: var(--radius);
   }
   .md-body pre {
     background: var(--bg-2);
     padding: 0.8em 1em;
-    border-radius: var(--radius);
     overflow-x: auto;
   }
   .md-body pre code {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,13 +35,21 @@
 
 /* Ledger tokens. Paper and ink by default; dark is the same set inverted.
    Values come from the resume canvas (epic #37): copy them, do not round.
-   --accent is the only place the accent colour lives (#44 adds a picker). */
+   --accent is the only place the SITE accent lives (#44 adds a picker); the
+   resume sheet carries its own (src/data/resume-sheet.ts). */
 :root {
   color-scheme: light;
-  --bg: #f4f2ec;
+
+  /* Theme-invariant: the ink band and accent tiles look the same in both themes. */
+  --ink: #111;
+  --paper: #f4f2ec;
+  --paper-muted: #cfcbc2;
+  --on-accent: var(--ink);
+
+  --bg: var(--paper);
   --bg-2: var(--bg);
   --surface: var(--bg);
-  --text: #111;
+  --text: var(--ink);
   --muted: #444;
   --faint: #6b6b6b;
   --line: #d3d0c6;
@@ -49,8 +57,6 @@
   --green: #167c4a;
   --amber: #9d6100;
   --danger: #b3261e;
-  --shadow: none;
-  --radius: 0;
   --rule-strong: 1.5px solid var(--text);
   --rule: 1px solid var(--line);
   --font-body: 'Space Grotesk', system-ui, sans-serif;
@@ -69,13 +75,15 @@
   --tracking-numbers: -0.03em;
   --tracking-mono: 0.08em;
   --tracking-chip: 0.12em;
+  --leading-display: 0.9;
+  --leading-body: 1.4;
 }
 
 :root[data-theme='dark'] {
   color-scheme: dark;
-  --bg: #111;
-  --text: #f4f2ec;
-  --muted: #cfcbc2;
+  --bg: var(--ink);
+  --text: var(--paper);
+  --muted: var(--paper-muted);
   --faint: #8a8a8a;
   --line: #2c2c2c;
   --green: #75e3a0;
@@ -89,7 +97,7 @@
   :root[data-theme='dark'] {
     color-scheme: light;
     --bg: #fff;
-    --text: #111;
+    --text: var(--ink);
     --muted: #444;
     --faint: #6b6b6b;
     --line: #d3d0c6;
@@ -97,19 +105,6 @@
     --amber: #9d6100;
     --danger: #b3261e;
   }
-}
-
-/* Tailwind's rounded-* utilities (private app area) resolve to these; zero
-   them so nothing renders a corner radius. */
-@theme {
-  --radius-xs: 0;
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
-  --radius-xl: 0;
-  --radius-2xl: 0;
-  --radius-3xl: 0;
-  --radius-4xl: 0;
 }
 
 * {
@@ -173,7 +168,6 @@ select {
   left: 12px;
   z-index: 100;
   padding: 10px 14px;
-  border-radius: var(--radius);
   background: var(--surface);
   color: var(--text);
   transform: translateY(-160%);
@@ -213,9 +207,8 @@ select {
   height: 32px;
   place-items: center;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--accent), transparent 80%);
-  color: var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
   font-family: var(--font-mono);
 }
 
@@ -227,7 +220,6 @@ select {
 
 .desktop-nav a,
 .mobile-panel a {
-  border-radius: var(--radius);
   color: var(--muted);
   font-size: 0.92rem;
   padding: 9px 11px;
@@ -253,7 +245,6 @@ select {
   height: 40px;
   place-items: center;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: var(--surface);
   color: var(--text);
   cursor: pointer;
@@ -281,7 +272,6 @@ select {
   min-width: 210px;
   padding: 10px;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: var(--surface);
 }
 
@@ -351,7 +341,6 @@ h3 {
   min-height: 44px;
   gap: 9px;
   border: 1px solid color-mix(in srgb, var(--accent), transparent 42%);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--accent), transparent 80%);
   color: var(--text);
   font-weight: 700;
@@ -376,7 +365,6 @@ h3 {
 
 .social-row a {
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.82rem;
@@ -396,7 +384,6 @@ h3 {
 .timeline-item,
 .post-card {
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: var(--surface);
 }
 
@@ -419,7 +406,6 @@ h3 {
   align-items: center;
   gap: 9px;
   border: 1px solid color-mix(in srgb, var(--green), transparent 48%);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--green), transparent 91%);
   color: var(--text);
   font-family: var(--font-mono);
@@ -430,7 +416,6 @@ h3 {
 .status-dot {
   width: 9px;
   height: 9px;
-  border-radius: var(--radius);
   background: var(--green);
   animation: pulse 2.4s infinite;
 }
@@ -445,7 +430,6 @@ h3 {
   margin-top: 24px;
   padding: 16px;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg), transparent 18%);
   color: var(--muted);
   font-family: var(--font-mono);
@@ -459,7 +443,6 @@ h3 {
   gap: 1px;
   overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: var(--line);
 }
 
@@ -559,7 +542,6 @@ h3 {
   align-items: center;
   gap: 6px;
   border: 1px solid color-mix(in srgb, var(--green), transparent 48%);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--green), transparent 91%);
   color: var(--text);
   font-family: var(--font-mono);
@@ -571,7 +553,6 @@ h3 {
 .repo-status-dot {
   width: 7px;
   height: 7px;
-  border-radius: var(--radius);
   background: var(--green);
 }
 
@@ -603,7 +584,6 @@ h3 {
 
 .tag {
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.74rem;
@@ -694,7 +674,6 @@ h3 {
 
 .prose code {
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg), transparent 10%);
   color: var(--green);
   font-family: var(--font-mono);
@@ -705,7 +684,6 @@ h3 {
   overflow-x: auto;
   padding: 18px;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: var(--bg-2);
 }
 
@@ -718,7 +696,6 @@ h3 {
 
 .blog-filter a {
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -734,7 +711,6 @@ h3 {
   display: inline-flex;
   width: fit-content;
   border: 1px solid color-mix(in srgb, var(--amber), transparent 45%);
-  border-radius: var(--radius);
   color: var(--amber);
   font-family: var(--font-mono);
   font-size: 0.72rem;
@@ -762,7 +738,6 @@ h3 {
 .contact-form textarea {
   width: 100%;
   border: 1px solid var(--line);
-  border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg), transparent 18%);
   color: var(--text);
   padding: 12px 13px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,64 +33,83 @@
   src: url('/fonts/SpaceMono-Bold.woff2') format('woff2');
 }
 
+/* Ledger tokens. Paper and ink by default; dark is the same set inverted.
+   Values come from the resume canvas (epic #37): copy them, do not round.
+   --accent is the only place the accent colour lives (#44 adds a picker). */
 :root {
+  color-scheme: light;
+  --bg: #f4f2ec;
+  --bg-2: var(--bg);
+  --surface: var(--bg);
+  --text: #111;
+  --muted: #444;
+  --faint: #6b6b6b;
+  --line: #d3d0c6;
+  --accent: #4dffb4;
+  --green: #167c4a;
+  --amber: #9d6100;
+  --danger: #b3261e;
+  --shadow: none;
+  --radius: 0;
+  --rule-strong: 1.5px solid var(--text);
+  --rule: 1px solid var(--line);
+  --font-body: 'Space Grotesk', system-ui, sans-serif;
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-mono: 'Space Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  /* Type ramp: the resume sheet's px scale (stack 8.5, meta 9, body 10.5,
+     headline 15, numbers 22, display 50) scaled so body lands on 16px. */
+  --text-xs: calc(8.5 / 10.5 * 1rem);
+  --text-sm: calc(9 / 10.5 * 1rem);
+  --text-base: 1rem;
+  --text-lg: calc(15 / 10.5 * 1rem);
+  --text-xl: calc(22 / 10.5 * 1rem);
+  --text-display: calc(50 / 10.5 * 1rem);
+  --tracking-display: -0.04em;
+  --tracking-numbers: -0.03em;
+  --tracking-mono: 0.08em;
+  --tracking-chip: 0.12em;
+}
+
+:root[data-theme='dark'] {
   color-scheme: dark;
-  --bg: #090b0f;
-  --bg-2: #10151b;
-  --surface: rgba(19, 25, 32, 0.82);
-  --surface-strong: rgba(25, 33, 42, 0.94);
-  --text: #eef5f8;
-  --muted: #a6b4bc;
-  --faint: #6f7d86;
-  --line: rgba(173, 216, 230, 0.16);
-  --accent: #28d8ff;
-  --accent-2: #a78bfa;
+  --bg: #111;
+  --text: #f4f2ec;
+  --muted: #cfcbc2;
+  --faint: #8a8a8a;
+  --line: #2c2c2c;
   --green: #75e3a0;
   --amber: #ffd166;
   --danger: #ff6b7a;
-  --shadow: 0 24px 80px rgba(0, 0, 0, 0.36);
-  --radius: 8px;
-  --font-body: 'Aptos', 'Segoe UI', system-ui, sans-serif;
-  --font-display: 'Cal Sans', 'Aptos', 'Segoe UI', system-ui, sans-serif;
-  --font-mono: 'SFMono-Regular', 'Cascadia Code', 'Liberation Mono', monospace;
 }
 
-:root[data-theme='light'] {
-  color-scheme: light;
-  --bg: #fbf8f1;
-  --bg-2: #f1eadf;
-  --surface: rgba(255, 252, 246, 0.88);
-  --surface-strong: rgba(255, 252, 246, 0.96);
-  --text: #172029;
-  --muted: #4f5f68;
-  --faint: #76838a;
-  --line: rgba(22, 45, 55, 0.16);
-  --accent: #007aa3;
-  --accent-2: #7257d6;
-  --green: #167c4a;
-  --amber: #9d6100;
-  --shadow: 0 24px 70px rgba(67, 53, 29, 0.14);
-}
-
-/* Print always uses the light palette, regardless of the on-screen theme. */
+/* Print always uses the light palette on white, regardless of the on-screen theme. */
 @media print {
   :root,
-  :root[data-theme='light'] {
+  :root[data-theme='dark'] {
     color-scheme: light;
     --bg: #fff;
-    --bg-2: #fff;
-    --surface: #fff;
-    --surface-strong: #fff;
-    --text: #172029;
-    --muted: #4f5f68;
-    --faint: #76838a;
-    --line: rgba(22, 45, 55, 0.16);
-    --accent: #007aa3;
-    --accent-2: #7257d6;
+    --text: #111;
+    --muted: #444;
+    --faint: #6b6b6b;
+    --line: #d3d0c6;
     --green: #167c4a;
     --amber: #9d6100;
-    --shadow: none;
+    --danger: #b3261e;
   }
+}
+
+/* Tailwind's rounded-* utilities (private app area) resolve to these; zero
+   them so nothing renders a corner radius. */
+@theme {
+  --radius-xs: 0;
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
+  --radius-xl: 0;
+  --radius-2xl: 0;
+  --radius-3xl: 0;
+  --radius-4xl: 0;
 }
 
 * {
@@ -105,26 +124,11 @@ html {
 body {
   min-height: 100vh;
   margin: 0;
-  background:
-    radial-gradient(circle at 12% 0%, rgba(40, 216, 255, 0.13), transparent 31rem),
-    radial-gradient(circle at 85% 10%, rgba(117, 227, 160, 0.1), transparent 28rem),
-    linear-gradient(180deg, var(--bg), var(--bg-2) 56%, var(--bg));
+  background: var(--bg);
   color: var(--text);
   font-family: var(--font-body);
   line-height: 1.65;
   text-rendering: optimizeLegibility;
-}
-
-body::before {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  content: '';
-  background-image:
-    linear-gradient(var(--line) 1px, transparent 1px), linear-gradient(90deg, var(--line) 1px, transparent 1px);
-  background-size: 64px 64px;
-  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.78), transparent 78%);
 }
 
 a {
@@ -132,9 +136,11 @@ a {
   text-decoration: none;
 }
 
+/* Accent as a text colour is unreadable on paper, so body links keep the ink and take the accent as their underline. */
 a:not([class]) {
-  color: var(--accent);
+  color: var(--text);
   text-decoration: underline;
+  text-decoration-color: var(--accent);
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.22em;
 }
@@ -147,7 +153,7 @@ select {
 }
 
 :focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--accent), white 15%);
+  outline: 3px solid var(--text);
   outline-offset: 4px;
 }
 
@@ -168,7 +174,7 @@ select {
   z-index: 100;
   padding: 10px 14px;
   border-radius: var(--radius);
-  background: var(--surface-strong);
+  background: var(--surface);
   color: var(--text);
   transform: translateY(-160%);
 }
@@ -182,8 +188,7 @@ select {
   top: 0;
   z-index: 50;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg), transparent 18%);
-  backdrop-filter: blur(18px);
+  background: var(--bg);
 }
 
 .nav-shell {
@@ -209,7 +214,7 @@ select {
   place-items: center;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: linear-gradient(135deg, color-mix(in srgb, var(--accent), transparent 80%), var(--surface));
+  background: color-mix(in srgb, var(--accent), transparent 80%);
   color: var(--accent);
   font-family: var(--font-mono);
 }
@@ -277,8 +282,7 @@ select {
   padding: 10px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--surface-strong);
-  box-shadow: var(--shadow);
+  background: var(--surface);
 }
 
 .hero {
@@ -307,8 +311,8 @@ h3 {
   font-family: var(--font-display);
   font-weight: 600;
   line-height: 1.02;
-  /* Fallback fonts (Linux: DejaVu Sans) are wider than Cal Sans; before the
-     webfont swaps in, a long heading word can spill past the viewport. */
+  /* Fallback fonts (Linux: DejaVu Sans) are wider than Space Grotesk; before
+     the webfont swaps in, a long heading word can spill past the viewport. */
   overflow-wrap: break-word;
 }
 
@@ -348,15 +352,10 @@ h3 {
   gap: 9px;
   border: 1px solid color-mix(in srgb, var(--accent), transparent 42%);
   border-radius: var(--radius);
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--accent), transparent 80%),
-    color-mix(in srgb, var(--accent-2), transparent 88%)
-  );
+  background: color-mix(in srgb, var(--accent), transparent 80%);
   color: var(--text);
   font-weight: 700;
   padding: 11px 16px;
-  box-shadow: 0 12px 34px color-mix(in srgb, var(--accent), transparent 86%);
 }
 
 .button:hover {
@@ -366,7 +365,6 @@ h3 {
 .button.secondary {
   border-color: var(--line);
   background: var(--surface);
-  box-shadow: none;
 }
 
 .social-row {
@@ -399,8 +397,7 @@ h3 {
 .post-card {
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--surface), white 2%), var(--surface)), var(--surface);
-  box-shadow: var(--shadow);
+  background: var(--surface);
 }
 
 .signal-card {
@@ -413,7 +410,7 @@ h3 {
   position: absolute;
   inset: 0 0 auto;
   height: 4px;
-  background: linear-gradient(90deg, var(--accent), var(--green), var(--amber));
+  background: var(--accent);
   content: '';
 }
 
@@ -422,7 +419,7 @@ h3 {
   align-items: center;
   gap: 9px;
   border: 1px solid color-mix(in srgb, var(--green), transparent 48%);
-  border-radius: 999px;
+  border-radius: var(--radius);
   background: color-mix(in srgb, var(--green), transparent 91%);
   color: var(--text);
   font-family: var(--font-mono);
@@ -433,15 +430,14 @@ h3 {
 .status-dot {
   width: 9px;
   height: 9px;
-  border-radius: 50%;
+  border-radius: var(--radius);
   background: var(--green);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--green), transparent 45%);
   animation: pulse 2.4s infinite;
 }
 
 @keyframes pulse {
-  70% {
-    box-shadow: 0 0 0 12px transparent;
+  50% {
+    opacity: 0.35;
   }
 }
 
@@ -563,7 +559,7 @@ h3 {
   align-items: center;
   gap: 6px;
   border: 1px solid color-mix(in srgb, var(--green), transparent 48%);
-  border-radius: 999px;
+  border-radius: var(--radius);
   background: color-mix(in srgb, var(--green), transparent 91%);
   color: var(--text);
   font-family: var(--font-mono);
@@ -575,7 +571,7 @@ h3 {
 .repo-status-dot {
   width: 7px;
   height: 7px;
-  border-radius: 50%;
+  border-radius: var(--radius);
   background: var(--green);
 }
 
@@ -586,7 +582,6 @@ h3 {
 
 .repo-status--pending .repo-status-dot {
   background: var(--amber);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--amber), transparent 45%);
   animation: pulse 2.4s infinite;
 }
 
@@ -608,7 +603,7 @@ h3 {
 
 .tag {
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.74rem;
@@ -699,7 +694,7 @@ h3 {
 
 .prose code {
   border: 1px solid var(--line);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: color-mix(in srgb, var(--bg), transparent 10%);
   color: var(--green);
   font-family: var(--font-mono);
@@ -711,7 +706,7 @@ h3 {
   padding: 18px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: #07090d;
+  background: var(--bg-2);
 }
 
 .blog-filter {
@@ -723,7 +718,7 @@ h3 {
 
 .blog-filter a {
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -739,7 +734,7 @@ h3 {
   display: inline-flex;
   width: fit-content;
   border: 1px solid color-mix(in srgb, var(--amber), transparent 45%);
-  border-radius: 999px;
+  border-radius: var(--radius);
   color: var(--amber);
   font-family: var(--font-mono);
   font-size: 0.72rem;


### PR DESCRIPTION
**What:** Swap the site's colours and fonts for the resume's paper-and-ink palette and type, with a dark version that is the same thing inverted.
**Why:** Every other redesign ticket builds on these values; doing them once here means the pages only have to change layout.
**Done when:** Loading any page shows the new fonts and colours in both light and dark mode, with the existing layouts unchanged.

Part of epic #37.

### What changed

- `src/styles/global.css`: token block replaced with the ledger set. Paper `#f4f2ec` / ink `#111` / `#444` / `#6b6b6b` / `#d3d0c6` by default; `data-theme='dark'` inverts to `#111` / `#f4f2ec` / `#cfcbc2` / `#8a8a8a` / `#2c2c2c`. `--accent: #4dffb4` is the only place the accent lives (`--accent-2` and `--surface-strong` removed). `--surface` is the page background, `--shadow: none`, `--radius: 0`. New `--rule`, `--rule-strong`, a `--text-xs`..`--text-display` ramp derived from the resume scale at a 16px body, and `--tracking-*` tokens. Fonts: Space Grotesk (body + display), Space Mono (mono).
- Body radial/linear gradients and the grid overlay removed; header glass (`backdrop-filter`), button/card/brand gradients and shadows removed; every literal `border-radius` now goes through `--radius`; the status-dot pulse animates opacity instead of a spreading shadow; `.prose pre` no longer hard-codes the old dark background.
- Tailwind `--radius-*` theme values zeroed so the app area's `rounded-md`/`rounded-lg` utilities render square.
- Body links keep ink as the text colour and take the accent as the underline; focus ring is ink. Mint as a text colour on paper is unreadable (the resume only ever uses it as a fill or on the ink masthead).
- `src/components/Layout.astro`: default is light when nothing is stored, respecting `prefers-color-scheme: dark`. Toggle and persistence unchanged.
- `src/layouts/AppLayout.astro`: two literal radii on `.md-body` code go through `--radius`.
- Print still forces the light palette (on white).

### Verified

- `bun run build` green; chromium e2e 50/50.
- Computed styles on `/`: light = `rgb(244,242,236)` bg / `rgb(17,17,17)` text, dark = the inverse, `Space Grotesk` body and `Space Mono` on `.eyebrow`/`.tag`, `--accent` `#4dffb4` in both. Toggle persists across reload and navigation; no stored theme follows `prefers-color-scheme`.
- `/resume`: `.sheet` and `.mast` computed colours are identical in both site themes.

### Left for later tickets

- `--green`, `--amber`, `--danger` are kept as status colours (app-area lesson status, availability badge) with per-theme values; the ledger palette has no equivalents, and #43 / #49 own their removal.
- `rounded-full` in `WorkspaceList.tsx` / `WorkspaceView.tsx` compiles to a literal radius, not a theme var; it still rounds. That's #43's area.
- `.eyebrow` / `.brand-mark` still colour with `--green` / `--accent`; #41 and #42 restyle those elements.
- Cal Sans `@font-face` stays until #49.

Closes #38
