### PR TITLE
feat(header): masthead header and footer as ink bands (#41)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,19 +5,24 @@ const year = new Date().getFullYear()
 ---
 
 <footer class="site-footer">
-  <div class="shell footer-shell">
-    <div>
-      <strong>{site.name}</strong>
-      <div>Built with Astro, TypeScript, Tailwind CSS, and a preference for calm shipping.</div>
-      <div>© {year}</div>
+  <div class="masthead-shell">
+    <div class="footer-brand">
+      <a class="masthead-name footer-name" href="/">{site.name}</a>
+      <p class="footer-note">Built with Astro, TypeScript, Tailwind CSS, and a preference for calm shipping.</p>
+      <p class="footer-note">© {year}</p>
     </div>
-    <nav class="footer-links" aria-label="Footer links">
-      <a href="/resume/">Resume</a>
-      <a href="/now/">Now</a>
-      <a href={site.github}>GitHub</a>
-      <a href={site.linkedin}>LinkedIn</a>
-      <a href={`mailto:${site.email}`}>Email</a>
-      <a href="/rss.xml">RSS</a>
-    </nav>
+    <div class="footer-cols">
+      <nav class="footer-links" aria-label="Footer links">
+        <a href="/resume/">Resume</a>
+        <a href="/now/">Now</a>
+        <a href="/rss.xml">RSS</a>
+      </nav>
+      <address class="footer-contact">
+        <a href={`mailto:${site.email}`}>Email</a>
+        <a href={site.github}>GitHub</a>
+        <a href={site.linkedin}>LinkedIn</a>
+        <span>{site.location}</span>
+      </address>
+    </div>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import ThemeToggle from '@/components/ThemeToggle.astro'
+import {resumeSheet} from '@/data/resume-sheet'
 import {navigation, site} from '@/data/site'
 
 const currentPath = Astro.url.pathname
@@ -10,32 +11,38 @@ function isCurrent(href: string) {
 ---
 
 <header class="site-header">
-  <div class="shell nav-shell">
-    <a class="brand" href="/" aria-label="Avi Charlop home">
-      <span class="brand-mark" aria-hidden="true">ac</span>
-      <span>{site.name}</span>
+  <div class="masthead-shell">
+    <a class="masthead-brand" href="/" aria-label="Avi Charlop home">
+      <span class="masthead-name">{site.name}</span>
+      <span class="masthead-role">{resumeSheet.title}</span>
     </a>
-    <nav class="desktop-nav" aria-label="Primary navigation">
-      {
-        navigation.map((item) => (
-          <a href={item.href} aria-current={isCurrent(item.href) ? 'page' : undefined}>
-            {item.label}
-          </a>
-        ))
-      }
-    </nav>
-    <div class="nav-actions">
-      <ThemeToggle />
-      <div class="mobile-nav">
-        <button class="menu-toggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="mobile-panel" data-menu-toggle>
-          <span aria-hidden="true">☰</span>
+    <div class="masthead-side">
+      <nav class="desktop-nav" aria-label="Primary navigation">
+        {
+          navigation.map((item) => (
+            <a href={item.href} aria-current={isCurrent(item.href) ? 'page' : undefined}>
+              {item.label}
+            </a>
+          ))
+        }
+      </nav>
+      <div class="nav-actions">
+        <ThemeToggle />
+        <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-panel" data-menu-toggle>
+          menu
         </button>
-        <nav class="mobile-panel" id="mobile-panel" aria-label="Mobile navigation" data-mobile-panel hidden>
-          {navigation.map((item) => <a href={item.href}>{item.label}</a>)}
-        </nav>
       </div>
     </div>
   </div>
+  <nav class="mobile-panel" id="mobile-panel" aria-label="Mobile navigation" data-mobile-panel hidden>
+    {
+      navigation.map((item) => (
+        <a href={item.href} aria-current={isCurrent(item.href) ? 'page' : undefined}>
+          {item.label}
+        </a>
+      ))
+    }
+  </nav>
 </header>
 
 <script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -177,59 +177,86 @@ select {
   transform: translateY(0);
 }
 
-.site-header {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  border-bottom: 1px solid var(--line);
-  background: var(--bg);
+/* Masthead: the resume's ink band. Always ink in both themes; the 1.5px rule
+   beneath it is --text, so it is invisible on paper and reads as a paper rule in
+   dark mode where the band would otherwise merge into the page. */
+.site-header,
+.site-footer {
+  padding: 20px 40px 16px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  letter-spacing: var(--tracking-mono);
+  text-transform: uppercase;
 }
 
-.nav-shell {
+.site-header {
+  border-bottom: var(--rule-strong);
+}
+
+.masthead-shell {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  max-width: 1180px;
+  margin-inline: auto;
+}
+
+.masthead-brand {
+  display: grid;
+  gap: 8px;
+}
+
+.masthead-name {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, var(--text-display));
+  font-weight: 700;
+  letter-spacing: var(--tracking-display);
+  line-height: var(--leading-display);
+  text-transform: uppercase;
+}
+
+.masthead-role {
+  color: var(--accent);
+}
+
+.masthead-side {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  min-height: 72px;
-  gap: 20px;
-}
-
-.brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-family: var(--font-display);
-  font-size: 1.05rem;
-}
-
-.brand-mark {
-  display: grid;
-  width: 32px;
-  height: 32px;
-  place-items: center;
-  border: 1px solid var(--line);
-  background: var(--accent);
-  color: var(--on-accent);
-  font-family: var(--font-mono);
+  gap: 24px;
 }
 
 .desktop-nav {
   display: flex;
-  align-items: center;
-  gap: 6px;
+  gap: 18px;
 }
 
+/* Band links are plain mono; the body's accent-underline rule for unclassed
+   links is reserved for marking the current page below. */
 .desktop-nav a,
-.mobile-panel a {
-  color: var(--muted);
-  font-size: 0.92rem;
-  padding: 9px 11px;
+.mobile-panel a,
+.footer-links a,
+.footer-contact a {
+  color: var(--paper-muted);
+  text-decoration: none;
 }
 
 .desktop-nav a:hover,
+.mobile-panel a:hover,
+.footer-links a:hover,
+.footer-contact a:hover {
+  color: var(--paper);
+}
+
 .desktop-nav a[aria-current='page'],
-.mobile-panel a:hover {
-  background: color-mix(in srgb, var(--accent), transparent 88%);
-  color: var(--text);
+.mobile-panel a[aria-current='page'] {
+  color: var(--paper);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 0.35em;
 }
 
 .nav-actions {
@@ -241,38 +268,41 @@ select {
 .theme-toggle,
 .menu-toggle {
   display: inline-grid;
-  width: 40px;
+  min-width: 40px;
   height: 40px;
   place-items: center;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  color: var(--text);
+  padding: 0 10px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   cursor: pointer;
 }
 
 .theme-toggle:hover,
 .menu-toggle:hover {
-  border-color: color-mix(in srgb, var(--accent), transparent 48%);
+  color: var(--accent);
 }
 
-.mobile-nav {
+.menu-toggle {
   display: none;
-  position: relative;
+}
+
+.mobile-panel {
+  display: grid;
+  max-width: 1180px;
+  margin: 16px auto 0;
 }
 
 .mobile-panel[hidden] {
   display: none;
 }
 
-.mobile-panel {
-  position: absolute;
-  top: 50px;
-  right: 0;
-  display: grid;
-  min-width: 210px;
-  padding: 10px;
-  border: 1px solid var(--line);
-  background: var(--surface);
+.mobile-panel a {
+  padding: 12px 0;
+  border-top: 1px solid color-mix(in srgb, var(--paper-muted) 30%, var(--ink));
 }
 
 .hero {
@@ -750,22 +780,35 @@ h3 {
 
 .site-footer {
   margin-top: 48px;
-  border-top: 1px solid var(--line);
-  padding: 34px 0;
-  color: var(--muted);
+  border-top: var(--rule-strong);
 }
 
-.footer-shell {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
+.footer-brand {
+  display: grid;
+  gap: 8px;
+  color: var(--paper-muted);
 }
 
-.footer-links {
+.footer-name {
+  font-size: var(--text-xl);
+  color: var(--paper);
+}
+
+.footer-note {
+  margin: 0;
+}
+
+.footer-cols {
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  gap: 40px;
+}
+
+.footer-links,
+.footer-contact {
+  display: grid;
+  gap: 6px;
+  font-style: normal;
+  text-align: right;
 }
 
 @media (max-width: 920px) {
@@ -773,8 +816,8 @@ h3 {
     display: none;
   }
 
-  .mobile-nav {
-    display: block;
+  .menu-toggle {
+    display: inline-grid;
   }
 
   .hero,
@@ -813,13 +856,24 @@ h3 {
     padding-top: 44px;
   }
 
-  .section-head,
-  .footer-shell {
+  .section-head {
     display: grid;
   }
 
-  .brand span:last-child {
-    display: none;
+  .site-header,
+  .site-footer {
+    padding: 16px 12px 12px;
+  }
+
+  .site-footer .masthead-shell,
+  .footer-cols {
+    display: grid;
+    gap: 20px;
+  }
+
+  .footer-links,
+  .footer-contact {
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
**What:** The site header and footer are now the resume's black masthead band: uppercase name, mono navigation, contact lines in the footer.
**Why:** The header is the first thing on every page and it still carried the old design's chrome.
**Done when:** Every page opens with the black band and ends with a matching footer, on desktop and mobile, in both themes.

## What changed

- `Header.astro`: ink band with the name in display uppercase, the resume title as a mono accent role line, mono navigation on the right in `--paper-muted`, and the `.nav-actions` slot (theme toggle + mobile `menu` toggle) kept intact for #44. Brand-mark square dropped; the name is the brand. Header is no longer sticky.
- Mobile: the band collapses to name + `menu`; the panel is a plain ruled list under the band (no blur, shadow, radius, or absolute positioning). Both nav lists carry `aria-current="page"`, marked with an accent underline.
- `Footer.astro`: matching ink band. Left: name, tagline, year. Right: alternate-format links (Resume, Now, RSS) and contact lines (Email, GitHub, LinkedIn, location). Every link that existed before is still there.
- `global.css`: old `.site-header`, `.brand*`, `.nav-shell`, `.mobile-nav`, `.footer-shell` rules removed; new masthead rules consume the #38 tokens only (no hex). Both bands carry `border: var(--rule-strong)`, which is invisible on paper and becomes the 1.5px paper rule in dark mode. Print rules in `ResumeSheet.astro` still match (`header.site-header`, `footer`).

Full e2e suite (chromium + mobile-safari) passes.

Closes #41
